### PR TITLE
Make compatible with linksystem branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-ipld-format v0.2.0
-	github.com/ipld/go-ipld-prime v0.7.0
+	github.com/ipld/go-ipld-prime v0.7.1-0.20210225173718-8fef5312eb12
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/ipfs/go-ipld-format v0.2.0 h1:xGlJKkArkmBvowr+GMCX0FEZtkro71K1AwiKnL3
 github.com/ipfs/go-ipld-format v0.2.0/go.mod h1:3l3C1uKoadTPbeNfrDi+xMInYKlx2Cvg1BuydPSdzQs=
 github.com/ipld/go-ipld-prime v0.7.0 h1:eigF1ZpaL1prbsKYVMqPLoPJqD/pzkQOe2j1uzvVg7w=
 github.com/ipld/go-ipld-prime v0.7.0/go.mod h1:0xEgdD6MKbZ1vF0GC+YcR/C4SQCAlRuOjIJ2i0HxqzM=
+github.com/ipld/go-ipld-prime v0.7.1-0.20210225173718-8fef5312eb12 h1:O9VMUYa2ktly9ql6W0LG0k8lXqg3bqz2ZfbaHXN3law=
+github.com/ipld/go-ipld-prime v0.7.1-0.20210225173718-8fef5312eb12/go.mod h1:0xEgdD6MKbZ1vF0GC+YcR/C4SQCAlRuOjIJ2i0HxqzM=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=

--- a/node.go
+++ b/node.go
@@ -2,7 +2,6 @@ package ipldlegacy
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,7 +102,7 @@ func (ln *LegacyNode) Resolve(path []string) (interface{}, []string, error) {
 		return &format.Link{Cid: link.(cidlink.Link).Cid}, remainingStrings, nil
 	}
 	buf := new(bytes.Buffer)
-	err = dagjson.Encoder(n, buf)
+	err = dagjson.Encode(n, buf)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -192,8 +191,9 @@ func (ln *LegacyNode) ResolveLink(path []string) (*format.Link, []string, error)
 
 // Copy returns a deep copy of this node
 func (ln *LegacyNode) Copy() format.Node {
-	nd, _ := DecodeNode(context.TODO(), ln.Block)
-	return nd
+	nb := ln.Node.Prototype().NewBuilder()
+	_ = nb.AssignNode(ln.Node)
+	return &LegacyNode{ln.Block, nb.Build()}
 }
 
 // Links is a helper function that returns all links within this object


### PR DESCRIPTION
# Goals

Update to go-ipld-prime linksystem branch (minus multihash changes incoming)

# Implementation

- change Copy() to no longer use DecodeNode ( a very unusual way to copy a node -- we should be using a node builder + AssignNode)
- assemble a linksystem on demand in DecodeNode -- this is an extra memory allocation -- we may pay some penalty for this